### PR TITLE
Adding duration to authorize_options

### DIFF
--- a/lib/omniauth/strategies/reddit.rb
+++ b/lib/omniauth/strategies/reddit.rb
@@ -8,6 +8,7 @@ module OmniAuth
       #class NoAuthorizationCodeError < StandardError; end
 
       option :name, "reddit"
+      option :authorize_options, [:scope, :duration]
 
       option :client_options, {
         site: 'https://ssl.reddit.com',


### PR DESCRIPTION
Duration is a reddit authorize option that allows a token to live for more than 1 hour.
