### PR TITLE
Remove 'email' from auth info hash; this isn't supported by the reddit API

### DIFF
--- a/lib/omniauth/strategies/reddit.rb
+++ b/lib/omniauth/strategies/reddit.rb
@@ -19,8 +19,7 @@ module OmniAuth
 
       info do
         {
-          name: raw_info['name'],
-          email: raw_info['email']
+          name: raw_info['name']
         }
       end
 


### PR DESCRIPTION
Hi

Just to reduce confusion for anyone else, this commit updates the info hash to remove the 'email' field. It's not returned anywhere by the Reddit API.
